### PR TITLE
Added code to retain original volume tags to new volumes

### DIFF
--- a/volume_encryption.py
+++ b/volume_encryption.py
@@ -192,6 +192,10 @@ def main(argv):
                 VolumeType=volume.volume_type,
                 AvailabilityZone=instance.placement['AvailabilityZone']
             )
+     
+        # Add original tags to new volume 
+        if volume.tags:
+            volume_encrypted.create_tags(Tags=volume.tags)
     
         """ Step 4: Detach current volume """
         print('---Detach volume {}'.format(volume.id))


### PR DESCRIPTION
Hi,
Thanks for your work, while using it I found out current code does not preserve tags if an unencrypted volume has tags on it. I have made a change so that script will create the same tags on new encrypted volumes as well. Please review the changes.